### PR TITLE
Feature backend healthcare organization api

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -64,6 +64,16 @@ connectToMySQL()
   });
 
 
+//Catch malformed JSON bodies
+app.use((err, req, res, next) => {
+  if (err instanceof SyntaxError && err.status === 400 && "body" in err) {
+    return res
+      .status(400)
+      .json({ error: "Invalid JSON payload. Please check your request body." });
+  }
+  next(err);
+});
+
 // 6. Start listening
 const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -30,12 +30,18 @@ app.get("/health", (req, res) => {
 // Import the MongoDB connection helper and the test router
 import { connectToMongoDB } from "../database/mongodb_db/mongodb_connection.js";
 import submissionRouter from "./routes/submissions.js"
+import organizationsRouter from "./routes/organizations.js"
 
 // 4. Connect to MongoDB, then mount only the test route
 connectToMongoDB()
   .then(() => {
+    // Mount the submissions router
     console.log("✅ MongoDB connected. Now mounting /submissions.js routes....")
     app.use("/submissions", submissionRouter)
+
+    // Mount the Organizations router
+    console.log("Mounting Organizations router.....")
+    app.use("/organizations", organizationsRouter)
   })
   .catch((err) => {
     console.error("❌ Failed to connect to MongoDB:", err);

--- a/backend/src/routes/organizations.js
+++ b/backend/src/routes/organizations.js
@@ -1,0 +1,23 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import HealthcareOrganization from '../../database/mongodb_db/models/HealthCareOrganization.js';
+
+// Set router
+const router = express.Router();
+
+/**
+ * GET /submissions
+ * --> This route returns all wait time submissions in the Wait Time Submission collection in mongodb
+ */
+router.get('/', async (req, res) => {
+    try {
+        const allHealthcareOrganizations = await HealthcareOrganization.find().lean();
+        res.json(allHealthcareOrganizations)
+    } catch (error) {
+        console.log(error)
+        res.status(500).json({error: 'Could not fetch healthcare organizational data'})
+    }
+})
+
+
+export default router;

--- a/backend/src/routes/organizations.js
+++ b/backend/src/routes/organizations.js
@@ -6,8 +6,8 @@ import HealthcareOrganization from '../../database/mongodb_db/models/HealthCareO
 const router = express.Router();
 
 /**
- * GET /submissions
- * --> This route returns all wait time submissions in the Wait Time Submission collection in mongodb
+ * GET /organizations
+ * --> This route returns all healthcare organizations in the healthcare_organization collection in mongodb
  */
 router.get('/', async (req, res) => {
     try {
@@ -19,5 +19,55 @@ router.get('/', async (req, res) => {
     }
 })
 
+/**
+ * GET /organizations/orgID
+ * --> This route returns the data of a healthcare organization using its id
+ */
+router.get('/:orgID', async (req, res) => {
+    // Get organization ID
+    const {orgID} = req.params;
+
+    // First check if the org id is valid
+    if (!mongoose.Types.ObjectId.isValid(orgID)) {
+        return res.status(400).json({error: 'Error! An invalid organization id was entered'})
+    }
+
+    try {
+
+        // Now get the data using the organization ID
+        const healthcareOrganization = await HealthcareOrganization.find({_id: orgID}).lean();
+
+         // If nothing was found
+        if (!healthcareOrganization) {
+            return res.status(404).json({message: `No organization found`})
+        }
+
+        res.json(healthcareOrganization)
+
+    } catch (error) {
+        console.log(error)
+        res.status(500).json({error: 'Could not fetch healthcare organizational data'})
+    }
+})
+
+/**
+ * POST /organizations/
+ * --> This route adds a single organization to the database
+ */
+
+router.post('/', async (req, res) => {
+    
+    try {
+         // Get the data from the req.json
+        const newOrganization = await HealthcareOrganization.create(req.body)
+        res.status(201).json({message: 'Successfully created new organization'})
+    }
+    catch (error) {
+        if (error.name === 'ValidationError') {
+            return res.status(400).json({ error: error.message });
+        }
+        return res.status(500).json({ error: 'Internal server error' });
+    }   
+})
 
 export default router;

--- a/backend/src/routes/organizations.js
+++ b/backend/src/routes/organizations.js
@@ -5,6 +5,13 @@ import HealthcareOrganization from '../../database/mongodb_db/models/HealthCareO
 // Set router
 const router = express.Router();
 
+// Import dotenv
+import dotenv from "dotenv";
+dotenv.config();
+
+// Get the auth header
+const authToken = process.env.AUTHORIZATION_TOKEN
+
 /**
  * GET /organizations
  * --> This route returns all healthcare organizations in the healthcare_organization collection in mongodb
@@ -56,11 +63,26 @@ router.get('/:orgID', async (req, res) => {
  */
 
 router.post('/', async (req, res) => {
+    // First get the authorization header
+    const authorization = req.headers.authorization
+    
+    // Check if request included auth header
+    if (!authorization) {
+        return res.status(401).json({message: 'Authorization header is missing'})
+    }
+
+    // Expecting format: "Bearer token"
+    const token = authorization.split(' ')[1];
+
+    // Validate auth header
+    if (!token || token != authToken) {
+        return res.status(401).json({message: 'Invalid Authorization token'})
+    }
     
     try {
          // Get the data from the req.json
         const newOrganization = await HealthcareOrganization.create(req.body)
-        res.status(201).json({message: 'Successfully created new organization'})
+        return res.status(201).json({message: 'Successfully created new organization'})
     }
     catch (error) {
         if (error.name === 'ValidationError') {


### PR DESCRIPTION
This PR introduces a full set of RESTful endpoints for the HealthcareOrganization resource:

GET /organizations
Returns all healthcare organizations stored in MongoDB.

GET /organizations/:orgID
Fetches a single organization by its MongoDB _id. Returns 200 with the organization data or 404 if not found.

POST /organizations
Creates a new organization from JSON in the request body. This route now enforces an Authorization header to ensure only authenticated clients can add records.
Example request body:
{
"organizationName": "Example Clinic",
"address": "123 Main St",
"organizationType": "Hospital",
"phoneNumber": "416-555-1212"
}

PUT /organizations/:orgID
Updates an existing organization’s details (name, address, type, phone) by its _id. Returns the updated document or 404 if the organization does not exist.

These changes complete the create, read, and update operations for our HealthcareOrganization API. Next steps include adding DELETE support, writing automated tests, and integrating real JWT authentication.