### PR TITLE
Styling Sidebar List - Part 1

### DIFF
--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -15,7 +15,7 @@ interface ClinicCardProps {
 
 export function ClinicCardSkeleton() {
   return (
-    <Card shadow="sm" padding="lg" radius="md" miw={400} withBorder>
+    <Card shadow="sm" padding="lg" radius="md" miw={436} withBorder>
       <Card.Section>
         <Group justify="flex-start" align="center" p="md">
           <Skeleton height={20} width={62} radius="sm" />
@@ -46,7 +46,7 @@ function ClinicCard({ clinic }: ClinicCardProps) {
     clinic.distance != null ? (clinic.distance / 1000).toFixed(2) : null;
 
   return (
-    <Card shadow="sm" padding="lg" radius="md" withBorder>
+    <Card shadow="sm" padding="lg" radius="md" miw={436} withBorder>
       <Card.Section>
         <Group justify="flex-start" align="center" p="md">
           <Badge color="blue" variant="light">

--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -64,8 +64,20 @@ function ClinicCard({ clinic }: ClinicCardProps) {
       </Card.Section>
 
       <Group justify="space-between" mb="xs">
-        <Text className="montserrat-bold" fz="lg">{clinic.name}</Text>
-        <Badge color="pink">{clinic.estimatedWaitTime}</Badge>
+        <Text
+            className="montserrat-bold"
+            fz="lg"
+            style={{flex:1, midWidth:0}}
+            lineClamp={2}
+        >
+            {clinic.name}
+        </Text>
+        <Badge
+            color="pink"
+            style={{ flexShrink: 0, alignSelf: "center" }}
+        >
+            {clinic.estimatedWaitTime}
+        </Badge>
       </Group>
       <Stack gap="0">
         <Text>

--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -64,7 +64,7 @@ function ClinicCard({ clinic }: ClinicCardProps) {
       </Card.Section>
 
       <Group justify="space-between" mb="xs">
-        <Text fw={500}>{clinic.name}</Text>
+        <Text className="montserrat-bold" fz="lg">{clinic.name}</Text>
         <Badge color="pink">{clinic.estimatedWaitTime}</Badge>
       </Group>
       <Stack gap="0">

--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -98,22 +98,37 @@ function ClinicCard({ clinic }: ClinicCardProps) {
 
             {/*Buttons*/}
             <Group justify="center" mt="md">
-                <Button color="blue"  radius="md" h={60} w={125}>
+                <Button color="blue"  radius="md" h={60} w={125} p="xs">
                     <Stack gap={4} align="center">
                         <IconMapPin2 size={20} />
-                        <Text size="sm">Directions</Text>
+                        <Text
+                            className="montserrat-med"
+                            size="xs"
+                        >
+                            DIRECTIONS
+                        </Text>
                     </Stack>
                 </Button>
-                <Button color="blue" radius="md" h={60} w={125}>
+                <Button color="blue" radius="md" h={60} w={125} p="xs">
                     <Stack gap={4} align="center">
                         <IconHourglassEmpty size={20} />
-                        <Text size="sm">Suggest Time</Text>
+                        <Text
+                            className="montserrat-med"
+                            size="xs"
+                        >
+                            SUGGEST TIME
+                        </Text>
                     </Stack>
                 </Button>
-                <Button color="blue" radius="md" h={60} w={125}>
+                <Button color="blue" radius="md" h={60} w={125} p="xs">
                     <Stack gap={4} align="center">
                         <IconInfoCircle size={20} />
-                        <Text size="sm">More Info</Text>
+                        <Text
+                            className="montserrat-med"
+                            size="xs"
+                        >
+                            MORE INFO
+                        </Text>
                     </Stack>
                 </Button>
             </Group>

--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -8,7 +8,7 @@ import {
   Text,
 } from "@mantine/core";
 import { Clinic } from "@models/clinic";
-import { IconMapPin2, IconHourglassEmpty, IconInfoCircle } from "@tabler/icons-react";
+import { IconMapPin2, IconHourglassEmpty, IconInfoCircle, IconClockHour2, IconUserPin } from "@tabler/icons-react";
 
 interface ClinicCardProps {
   clinic: Clinic;
@@ -79,11 +79,18 @@ function ClinicCard({ clinic }: ClinicCardProps) {
             {clinic.estimatedWaitTime}
         </Badge>
       </Group>
-      <Stack gap="0">
-        <Text>
-          {distanceKm ? `Distance: ${distanceKm} km away` : "Distance: unknown"}
-        </Text>
-        <Text>Closing time: {clinic.closingTime}</Text>
+      <Stack gap={2}>
+          <Group gap="xs">
+              <IconUserPin size={16} />
+              <Text
+                  size ="sm">
+                  {distanceKm ? `${distanceKm} km away from you` : "Distance: unknown"}
+              </Text>
+          </Group>
+          <Group gap="xs">
+              <IconClockHour2 size={16} />
+              <Text size ="sm"> Closes at {clinic.closingTime}</Text>
+          </Group>
       </Stack>
       <Group justify="center" mt="md">
         <Button color="blue"  radius="md" h={60} w={125}>

--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -8,6 +8,7 @@ import {
   Text,
 } from "@mantine/core";
 import { Clinic } from "@models/clinic";
+import { IconMapPin2, IconHourglassEmpty, IconInfoCircle } from "@tabler/icons-react";
 
 interface ClinicCardProps {
   clinic: Clinic;
@@ -46,7 +47,7 @@ function ClinicCard({ clinic }: ClinicCardProps) {
     clinic.distance != null ? (clinic.distance / 1000).toFixed(2) : null;
 
   return (
-    <Card shadow="sm" padding="lg" radius="md" miw={436} withBorder>
+    <Card shadow="sm" padding="lg" radius="md" miw={450} withBorder>
       <Card.Section>
         <Group justify="flex-start" align="center" p="md">
           <Badge color="blue" variant="light">
@@ -72,15 +73,24 @@ function ClinicCard({ clinic }: ClinicCardProps) {
         </Text>
         <Text>Closing time: {clinic.closingTime}</Text>
       </Stack>
-      <Group>
-        <Button color="blue" mt="md" radius="md">
-          Directions
+      <Group justify="center" mt="md">
+        <Button color="blue"  radius="md" h={60} w={125}>
+            <Stack gap={4} align="center">
+                <IconMapPin2 size={20} />
+                <Text size="sm">Directions</Text>
+            </Stack>
         </Button>
-        <Button color="blue" mt="md" radius="md">
-          Website
+        <Button color="blue" radius="md" h={60} w={125}>
+            <Stack gap={4} align="center">
+                <IconHourglassEmpty size={20} />
+                <Text size="sm">Suggest Time</Text>
+            </Stack>
         </Button>
-        <Button color="blue" mt="md" radius="md">
-          More info
+        <Button color="blue" radius="md" h={60} w={125}>
+            <Stack gap={4} align="center">
+                <IconInfoCircle size={20} />
+                <Text size="sm">More Info</Text>
+            </Stack>
         </Button>
       </Group>
     </Card>

--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -1,119 +1,124 @@
 import {
-  Badge,
-  Button,
-  Card,
-  Group,
-  Skeleton,
-  Stack,
-  Text,
+    Badge,
+    Button,
+    Card,
+    Group,
+    Skeleton,
+    Stack,
+    Text,
 } from "@mantine/core";
 import { Clinic } from "@models/clinic";
 import { IconMapPin2, IconHourglassEmpty, IconInfoCircle, IconClockHour2, IconUserPin } from "@tabler/icons-react";
 
 interface ClinicCardProps {
-  clinic: Clinic;
+    clinic: Clinic;
 }
 
 export function ClinicCardSkeleton() {
-  return (
-    <Card shadow="sm" padding="lg" radius="md" miw={436} withBorder>
-      <Card.Section>
-        <Group justify="flex-start" align="center" p="md">
-          <Skeleton height={20} width={62} radius="sm" />
-          <Skeleton height={20} width={62} radius="sm" />
-        </Group>
-      </Card.Section>
+    return (
+        <Card shadow="sm" padding="lg" radius="md" miw={436} withBorder>
+            <Card.Section>
+                <Group justify="flex-start" align="center" p="md">
+                    <Skeleton height={20} width={62} radius="sm" />
+                    <Skeleton height={20} width={62} radius="sm" />
+                </Group>
+            </Card.Section>
 
-      <Group justify="space-between" mb="xs">
-        <Skeleton height={25} width={150} radius="sm" />
-        <Skeleton height={20} width={42} radius="sm" />
-      </Group>
-      <Stack gap="0">
-        <Skeleton height={24} width="70%" radius="sm" />
-        <Skeleton height={24} width="60%" radius="sm" />
-      </Stack>
-      <Group>
-        <Skeleton height={36} width={100} mt="md" radius="md" />
-        <Skeleton height={36} width={100} mt="md" radius="md" />
-        <Skeleton height={36} width={100} mt="md" radius="md" />
-      </Group>
-    </Card>
-  );
+            <Group justify="space-between" mb="xs">
+                <Skeleton height={25} width={150} radius="sm" />
+                <Skeleton height={20} width={42} radius="sm" />
+            </Group>
+            <Stack gap="0">
+                <Skeleton height={24} width="70%" radius="sm" />
+                <Skeleton height={24} width="60%" radius="sm" />
+            </Stack>
+            <Group>
+                <Skeleton height={36} width={100} mt="md" radius="md" />
+                <Skeleton height={36} width={100} mt="md" radius="md" />
+                <Skeleton height={36} width={100} mt="md" radius="md" />
+            </Group>
+        </Card>
+    );
 }
 
 // Kilometers function
 function ClinicCard({ clinic }: ClinicCardProps) {
-  const distanceKm =
-    clinic.distance != null ? (clinic.distance / 1000).toFixed(2) : null;
+    const distanceKm =
+        clinic.distance != null ? (clinic.distance / 1000).toFixed(2) : null;
 
-  return (
-    <Card shadow="sm" padding="lg" radius="md" miw={450} withBorder>
-      <Card.Section>
-        <Group justify="flex-start" align="center" p="md">
-          <Badge color="blue" variant="light">
-            <Text size="xs" c="dimmed">
-              {clinic.type}
-            </Text>
-          </Badge>
-          <Badge color={clinic.isOpen ? "green" : "red"} variant="light">
-            <Text size="xs" c="dimmed">
-              {clinic.isOpen ? "OPEN" : "CLOSED"}
-            </Text>
-          </Badge>
-        </Group>
-      </Card.Section>
+    return (
+        <Card shadow="sm" padding="lg" radius="md" miw={450} withBorder>
+            {/*Labels*/}
+            <Card.Section>
+                <Group justify="flex-start" align="center" p="md">
+                    <Badge color="blue" variant="light">
+                        <Text size="xs" c="dimmed">
+                            {clinic.type}
+                        </Text>
+                    </Badge>
+                    <Badge color={clinic.isOpen ? "green" : "red"} variant="light">
+                        <Text size="xs" c="dimmed">
+                            {clinic.isOpen ? "OPEN" : "CLOSED"}
+                        </Text>
+                    </Badge>
+                </Group>
+            </Card.Section>
 
-      <Group justify="space-between" mb="xs">
-        <Text
-            className="montserrat-bold"
-            fz="lg"
-            style={{flex:1, midWidth:0}}
-            lineClamp={2}
-        >
-            {clinic.name}
-        </Text>
-        <Badge
-            color="pink"
-            style={{ flexShrink: 0, alignSelf: "center" }}
-        >
-            {clinic.estimatedWaitTime}
-        </Badge>
-      </Group>
-      <Stack gap={2}>
-          <Group gap="xs">
-              <IconUserPin size={16} />
-              <Text
-                  size ="sm">
-                  {distanceKm ? `${distanceKm} km away from you` : "Distance: unknown"}
-              </Text>
-          </Group>
-          <Group gap="xs">
-              <IconClockHour2 size={16} />
-              <Text size ="sm"> Closes at {clinic.closingTime}</Text>
-          </Group>
-      </Stack>
-      <Group justify="center" mt="md">
-        <Button color="blue"  radius="md" h={60} w={125}>
-            <Stack gap={4} align="center">
-                <IconMapPin2 size={20} />
-                <Text size="sm">Directions</Text>
+            {/*Clinic Name and Estimated Wait Time*/}
+            <Group justify="space-between" mb="xs">
+                <Text
+                    className="montserrat-bold"
+                    fz="lg"
+                    style={{flex:1, midWidth:0}}
+                    lineClamp={2}
+                >
+                    {clinic.name}
+                </Text>
+                <Badge
+                    color="pink"
+                    style={{ flexShrink: 0, alignSelf: "center" }}
+                >
+                    {clinic.estimatedWaitTime}
+                </Badge>
+            </Group>
+
+            {/*Distance and Closing Time Groups*/}
+            <Stack gap={2}>
+                <Group gap="xs">
+                    <IconUserPin size={16} />
+                    <Text size ="sm">
+                        {distanceKm ? `${distanceKm} km away from you` : "Distance: unknown"}
+                    </Text>
+                </Group>
+                <Group gap="xs">
+                    <IconClockHour2 size={16} />
+                    <Text size ="sm"> Closes at {clinic.closingTime}</Text>
+                </Group>
             </Stack>
-        </Button>
-        <Button color="blue" radius="md" h={60} w={125}>
-            <Stack gap={4} align="center">
-                <IconHourglassEmpty size={20} />
-                <Text size="sm">Suggest Time</Text>
-            </Stack>
-        </Button>
-        <Button color="blue" radius="md" h={60} w={125}>
-            <Stack gap={4} align="center">
-                <IconInfoCircle size={20} />
-                <Text size="sm">More Info</Text>
-            </Stack>
-        </Button>
-      </Group>
-    </Card>
-  );
+
+            {/*Buttons*/}
+            <Group justify="center" mt="md">
+                <Button color="blue"  radius="md" h={60} w={125}>
+                    <Stack gap={4} align="center">
+                        <IconMapPin2 size={20} />
+                        <Text size="sm">Directions</Text>
+                    </Stack>
+                </Button>
+                <Button color="blue" radius="md" h={60} w={125}>
+                    <Stack gap={4} align="center">
+                        <IconHourglassEmpty size={20} />
+                        <Text size="sm">Suggest Time</Text>
+                    </Stack>
+                </Button>
+                <Button color="blue" radius="md" h={60} w={125}>
+                    <Stack gap={4} align="center">
+                        <IconInfoCircle size={20} />
+                        <Text size="sm">More Info</Text>
+                    </Stack>
+                </Button>
+            </Group>
+        </Card>
+    );
 }
 
 export default ClinicCard;

--- a/frontend/src/app/components/clinic/clinic-list.tsx
+++ b/frontend/src/app/components/clinic/clinic-list.tsx
@@ -27,7 +27,7 @@ export default function ClinicList() {
 
   return (
     <>
-      <Stack h="90vh" maw={436} mx="auto">
+      <Stack h="90vh" maw={450} mx="auto">
         <Input
           placeholder="Enter address to find nearest location"
           rightSectionPointerEvents="all"

--- a/frontend/src/app/components/clinic/clinic-list.tsx
+++ b/frontend/src/app/components/clinic/clinic-list.tsx
@@ -27,9 +27,8 @@ export default function ClinicList() {
 
   return (
     <>
-      <Stack h="90vh" maw={400}>
+      <Stack h="90vh" maw={436} mx="auto">
         <Input
-          mr="sm"
           placeholder="Enter address to find nearest location"
           rightSectionPointerEvents="all"
           rightSection={
@@ -38,7 +37,7 @@ export default function ClinicList() {
             </ActionIcon>
           }
         ></Input>
-        <Group justify="space-between" align="center" mr="sm">
+        <Group justify="space-between" align="center">
           <Popover
             width={300}
             trapFocus
@@ -66,7 +65,7 @@ export default function ClinicList() {
 
         {loading ? (
           <ScrollArea>
-            <Stack mr="sm">
+            <Stack>
               {/* Display 3 skeleton cards while loading */}
               {Array(3)
                 .fill(0)
@@ -79,7 +78,7 @@ export default function ClinicList() {
           <Text>{error}</Text>
         ) : (
           <ScrollArea>
-            <Stack mr="sm">
+            <Stack>
               {filteredClinics.length > 0 ? (
                 filteredClinics.map((clinic) => (
                   <ClinicCard key={clinic.id} clinic={clinic} />

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -8,6 +11,34 @@
   margin: 0;
   padding: 0;
 }
+
+/* ===== FONTS ===== */
+.montserrat-bold {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+}
+
+.montserrat-semibold {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 600;
+}
+
+.open-sans-lt {
+  font-family: "Open Sans", sans-serif;
+  font-weight: 300;
+}
+
+.open-sans-reg {
+  font-family: "Open Sans", sans-serif;
+  font-weight: 400;
+}
+
+/* Font Sizes */
+.text-xs { font-size: 0.75rem; }
+.text-sm { font-size: 0.875rem; }
+.text-md { font-size: 1rem; }
+.text-lg { font-size: 1.125rem; }
+
 
 /* ===== HEADER STYLES ===== */
 .dark-header {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -23,6 +23,11 @@
   font-weight: 600;
 }
 
+.montserrat-med{
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 500;
+}
+
 .open-sans-lt {
   font-family: "Open Sans", sans-serif;
   font-weight: 300;


### PR DESCRIPTION
Changes For #41 - Sidebar List:

- implemented fixed width for clinic cards and centered clinic list across sidebar container 
- centered clinic card buttons
-- added icons and switched Website to "Suggest Time" button
-- also changed button font
- changed font for Clinic name
- fixed Clinic Name to wrap multiple lines without pushing the estimated wait time badge
-- it was pushing the wait time badge over along with it before
-- wait time should be fixed to the right side now. clinic name is also set to limit to only 2 lines
- adjusted text for Distance and Closing Time groups
-- added icons with it
![image](https://github.com/user-attachments/assets/39e51ca5-4a35-4b45-887d-5e974870061f)
vs. 
![image](https://github.com/user-attachments/assets/0ef74d7e-0b89-4bae-b57e-7f23e84e5840)
---
![image](https://github.com/user-attachments/assets/12d5fe8a-1e18-47dc-9d82-987e4cae96c3)

Note: This task is still incomplete.
- Will still need to update styling to better reflect dark/light mode themes
- Style search and filters components