### PR TITLE
Implemented Detailed View for each location (#18)

### DIFF
--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -62,7 +62,7 @@ interface ClinicCardProps {
   onMoreInfoClick: (clinic: Clinic) => void;
 }
 
-export default function ClinicCard({ clinic }: { clinic: Clinic }) {
+export default function ClinicCard({ clinic, onMoreInfoClick }: ClinicCardProps) {
   const distanceKm =
     clinic.distance != null && typeof clinic.distance === "number"
       ? (clinic.distance / 1000).toFixed(2)
@@ -148,7 +148,7 @@ export default function ClinicCard({ clinic }: { clinic: Clinic }) {
           </Stack>
         </Button>
 
-        <Button color="blue" radius="md" h={60} w={125} p="xs">
+        <Button color="blue" radius="md" h={60} w={125} p="xs" onClick={() => onMoreInfoClick(clinic)}>
           <Stack gap={4} align="center">
             <IconInfoCircle size={20} />
             <Text className="montserrat-med" size="xs">

--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -113,10 +113,11 @@ export default function ClinicCard({ clinic, onMoreInfoClick }: ClinicCardProps)
             {distanceKm ? `${distanceKm} km away from you` : "Distance unknown"}
           </Text>
         </Group>
-        <Group gap="xs">
-          <IconClockHour2 size={16} />
-          <Text size="sm">Closes at {clinic.closingTime}</Text>
-        </Group>
+        {/*Commenting out for the time being. Unable to add operating hours at this time. */}
+        {/*<Group gap="xs">*/}
+        {/*  <IconClockHour2 size={16} />*/}
+        {/*  <Text size="sm">Closes at {clinic.closingTime}</Text>*/}
+        {/*</Group>*/}
       </Stack>
 
       {/* ── Buttons ────────────────────────────────────────────── */}

--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -57,6 +57,11 @@ function waitTimeColour(wt: string) {
 }
 
 /* ─────────────────────────── Card ─────────────────────────── */
+interface ClinicCardProps {
+  clinic: Clinic;
+  onMoreInfoClick: (clinic: Clinic) => void;
+}
+
 export default function ClinicCard({ clinic }: { clinic: Clinic }) {
   const distanceKm =
     clinic.distance != null && typeof clinic.distance === "number"

--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -119,36 +119,6 @@ export default function ClinicCard({ clinic }: { clinic: Clinic }) {
         </Group>
       </Stack>
 
-      {/* ── NEW: Services / Hours / Contact ────────────────────── */}
-      {clinic.services && clinic.services.length > 0 && (
-        <Text size="sm" mt="sm">
-          <b>Services:</b> {clinic.services.join(", ")}
-        </Text>
-      )}
-
-      {clinic.hours && (
-        <Text size="sm">
-          <b>Hours:</b> {clinic.hours}
-        </Text>
-      )}
-
-      {clinic.contact && (clinic.contact.phone || clinic.contact.email) && (
-        <Text size="sm">
-          {clinic.contact.phone && (
-            <>
-              📞 {clinic.contact.phone}
-              <br />
-            </>
-          )}
-          {clinic.contact.email && (
-            <>
-              ✉️ {clinic.contact.email}
-              <br />
-            </>
-          )}
-        </Text>
-      )}
-
       {/* ── Buttons ────────────────────────────────────────────── */}
       <Group justify="center" mt="md">
         <Button

--- a/frontend/src/app/components/clinic/clinic-info.tsx
+++ b/frontend/src/app/components/clinic/clinic-info.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import React from "react";
+import {
+    Stack,
+    Text,
+    Group,
+    Badge,
+    Button,
+    Divider,
+    Box,
+    ScrollArea,
+    ActionIcon,
+} from "@mantine/core";
+import {
+    IconMapPin,
+    IconClock,
+    IconWorld,
+    IconPhone,
+    IconArrowLeft,
+    IconHourglassEmpty,
+    IconMapPin2,
+} from "@tabler/icons-react";
+import { Clinic } from "@/models/clinic";
+
+interface ClinicInfoPanelProps {
+    clinic: Clinic;
+    onBack: () => void;
+}
+
+function waitTimeColour(wt: string) {
+    const n = parseInt(wt);
+    if (isNaN(n)) return "gray";
+    if (n < 15) return "green";
+    if (n < 30) return "yellow";
+    return "red";
+}
+
+function formatOperatingHours(hours?: string) {
+    if (!hours || hours === "N/A" || hours === "Unknown") {
+        return [
+            { day: "Monday", hours: "Hours not available" },
+            { day: "Tuesday", hours: "Hours not available" },
+            { day: "Wednesday", hours: "Hours not available" },
+            { day: "Thursday", hours: "Hours not available" },
+            { day: "Friday", hours: "Hours not available" },
+            { day: "Saturday", hours: "Hours not available" },
+            { day: "Sunday", hours: "Hours not available" },
+        ];
+    }
+
+    const defaultHours = "Check with facility";
+    return [
+        { day: "Monday", hours: defaultHours },
+        { day: "Tuesday", hours: defaultHours },
+        { day: "Wednesday", hours: defaultHours },
+        { day: "Thursday", hours: defaultHours },
+        { day: "Friday", hours: defaultHours },
+        { day: "Saturday", hours: defaultHours },
+        { day: "Sunday", hours: defaultHours },
+    ];
+}
+
+function formatAddress(clinic: Clinic): string {
+    if (clinic.location?.lat && clinic.location?.lng) {
+        return `Coordinates: ${clinic.location.lat.toFixed(4)}, ${clinic.location.lng.toFixed(4)}`;
+    }
+    return "Address not available";
+}
+
+export default function ClinicInfoPanel({
+    clinic,
+    onBack,
+}: ClinicInfoPanelProps) {
+    const colour = waitTimeColour(clinic.estimatedWaitTime);
+    const operatingHours = formatOperatingHours(clinic.hours);
+    const address = formatAddress(clinic);
+    const mapsUrl = `https://www.google.com/maps/dir/?api=1&destination=${clinic.location.lat},${clinic.location.lng}`;
+
+    // calc distance display
+    const distanceKm =
+        clinic.distance != null && typeof clinic.distance === "number"
+            ? (clinic.distance / 1000).toFixed(2)
+            : null;
+
+    return (
+        <Stack h="90vh" maw={450} mx="auto">
+            {/* Header with back button */}
+            <Group>
+                <ActionIcon
+                    variant="subtle"
+                    onClick={onBack}
+                    size="lg"
+                >
+                    <IconArrowLeft size={20} />
+                </ActionIcon>
+                <Text size="sm" c="dimmed">Back to list</Text>
+            </Group>
+
+            <ScrollArea flex={1}>
+                <Stack gap="lg" p="xs">
+                    {/* Clinic Name */}
+                    <Text
+                        className="montserrat-bold"
+                        size="xl"
+                        ta="center"
+                        lineClamp={2}
+                    >
+                        {clinic.name}
+                    </Text>
+
+                    {/* Clinic Type and Status Badges */}
+                    <Group justify="center" gap="sm">
+                        <Badge color="blue" variant="light" size="lg">
+                            <Text size="sm" tt="uppercase">
+                                {clinic.type}
+                            </Text>
+                        </Badge>
+                        <Badge
+                            color={clinic.isOpen ? "green" : "red"}
+                            variant="light"
+                            size="lg"
+                        >
+                            <Text size="sm" tt="uppercase">
+                                {clinic.isOpen ? "Open Now" : "Closed"}
+                            </Text>
+                        </Badge>
+                    </Group>
+
+                    {/* Distance */}
+                    {distanceKm && (
+                        <Group justify="center">
+                            <Text size="sm" c="dimmed">
+                                {distanceKm} km away from you
+                            </Text>
+                        </Group>
+                    )}
+                    <Stack gap="md">
+
+                    {/* Address */}
+                    <Group gap="sm" align="flex-start">
+                        <IconMapPin size={20} style={{marginTop: 2, flexShrink: 0}}/>
+                        <Box flex={1}>
+                            <Text size="sm" fw={600} mb={2}>
+                                Address
+                            </Text>
+                            <Text size="sm" c="dimmed">
+                                {address}
+                            </Text>
+                        </Box>
+                    </Group>
+
+                    {/* Operating Hours */}
+                    <Group gap="sm" align="flex-start">
+                        <IconClock size={20} style={{marginTop: 2, flexShrink: 0}}/>
+                        <Box flex={1}>
+                            <Text size="sm" fw={600} mb={4}>
+                                Operating Hours
+                            </Text>
+                            <Stack gap={2}>
+                                {operatingHours.map((schedule) => (
+                                    <Group justify="space-between" key={schedule.day}>
+                                        <Text size="sm">{schedule.day}</Text>
+                                        <Text size="sm" c="dimmed">{schedule.hours}</Text>
+                                    </Group>
+                                ))}
+                            </Stack>
+                        </Box>
+                    </Group>
+
+                    {/* Phone Number */}
+                    <Group gap="sm" align="flex-start">
+                        <IconPhone size={20} style={{marginTop: 2, flexShrink: 0}}/>
+                        <Box flex={1}>
+                            <Text size="sm" fw={600} mb={2}>
+                                Phone
+                            </Text>
+                            {clinic.contact?.phone && clinic.contact.phone !== "Not available" ? (
+                                <Text
+                                    size="sm"
+                                    c="blue"
+                                    component="a"
+                                    href={`tel:${clinic.contact.phone}`}
+                                    style={{textDecoration: "underline"}}
+                                >
+                                    {clinic.contact.phone}
+                                </Text>
+                            ) : (
+                                <Text size="sm" c="dimmed">
+                                    Phone not available
+                                </Text>
+                            )}
+                        </Box>
+                    </Group>
+
+                    <Divider my="md"/>
+
+                    {/* Current Wait Time */}
+                    <Box>
+                        <Text size="lg" fw={600} mb="sm">
+                            Current Wait Time:
+                        </Text>
+                        <Group justify="space-between" align="center">
+                            <Text size="sm">
+                                Currently at the Clinic?
+                            </Text>
+                            <Badge color={colour} size="xl" variant="filled">
+                                <Text size="lg" fw={700}>
+                                    {clinic.estimatedWaitTime}
+                                </Text>
+                            </Badge>
+                        </Group>
+                    </Box>
+
+                    {/* Action Buttons */}
+                    <Stack gap="sm" mt="md">
+                        <Button
+                            color="blue"
+                            size="md"
+                            radius="md"
+                            leftSection={<IconHourglassEmpty size={20}/>}
+                        >
+                            Suggest Wait Time
+                        </Button>
+                        <Button
+                            color="blue"
+                            size="md"
+                            radius="md"
+                            variant="outline"
+                            leftSection={<IconMapPin2 size={20}/>}
+                            component="a"
+                            href={mapsUrl}
+                            target="_blank"
+                        >
+                            Get Directions
+                        </Button>
+                    </Stack>
+                </Stack>
+            </Stack>
+        </ScrollArea>
+    </Stack>
+);
+}

--- a/frontend/src/app/components/clinic/clinic-info.tsx
+++ b/frontend/src/app/components/clinic/clinic-info.tsx
@@ -229,7 +229,7 @@ export default function ClinicInfoPanel({
                             </Text>
                             <Stack gap={2}>
                                 <Text size="sm" c="orange" fw={500} mb={4}>
-                                    Coming Soon! Hours data not available from OpenStreetMap
+                                    Coming Soon! Hours data not available from OpenStreetMap.
                                 </Text>
                                 <Group justify="space-between">
                                     <Text size="sm">For current hours:</Text>
@@ -259,6 +259,45 @@ export default function ClinicInfoPanel({
                         </Box>
                     </Group>
 
+                    {/* Website */}
+                    <Group gap="sm" align="flex-start">
+                        <IconWorld size={20} style={{marginTop: 2, flexShrink: 0}}/>
+                        <Box flex={1}>
+                            <Text size="sm" fw={600} mb={2}>
+                                Website
+                            </Text>
+                            {clinic.contact?.website ||
+                            (clinic as any).website ||
+                            (clinic as any).tags?.website ||
+                            (clinic as any).tags?.["contact:website"] ? (
+                                <Text
+                                    size="sm"
+                                    c="blue"
+                                    component="a"
+                                    href={
+                                        clinic.contact?.website ||
+                                        (clinic as any).website ||
+                                        (clinic as any).tags?.website ||
+                                        (clinic as any).tags?.["contact:website"]
+                                    }
+                                    target="_blank"
+                                    style={{textDecoration: "underline"}}
+                                >
+                                    {(
+                                        clinic.contact?.website ||
+                                        (clinic as any).website ||
+                                        (clinic as any).tags?.website ||
+                                        (clinic as any).tags?.["contact:website"]
+                                    )?.replace(/^https?:\/\//, '')}
+                                </Text>
+                            ) : (
+                                <Text size="sm" c="dimmed">
+                                    Website is currently not available at this time.
+                                </Text>
+                            )}
+                        </Box>
+                    </Group>
+
                     {/* Phone Number */}
                     <Group gap="sm" align="flex-start">
                         <IconPhone size={20} style={{marginTop: 2, flexShrink: 0}}/>
@@ -278,7 +317,7 @@ export default function ClinicInfoPanel({
                                 </Text>
                             ) : (
                                 <Text size="sm" c="dimmed">
-                                    Phone currently not available.
+                                    Phone number is currently not available at this time.
                                 </Text>
                             )}
                         </Box>

--- a/frontend/src/app/components/clinic/clinic-info.tsx
+++ b/frontend/src/app/components/clinic/clinic-info.tsx
@@ -11,6 +11,7 @@ import {
     Box,
     ScrollArea,
     ActionIcon,
+    Skeleton,
 } from "@mantine/core";
 import {
     IconMapPin,
@@ -22,6 +23,7 @@ import {
     IconMapPin2,
 } from "@tabler/icons-react";
 import { Clinic } from "@/models/clinic";
+import { useClinicAddress } from "@/utils/address";
 
 interface ClinicInfoPanelProps {
     clinic: Clinic;
@@ -61,21 +63,16 @@ function formatOperatingHours(hours?: string) {
     ];
 }
 
-function formatAddress(clinic: Clinic): string {
-    if (clinic.location?.lat && clinic.location?.lng) {
-        return `Coordinates: ${clinic.location.lat.toFixed(4)}, ${clinic.location.lng.toFixed(4)}`;
-    }
-    return "Address not available";
-}
-
 export default function ClinicInfoPanel({
     clinic,
     onBack,
 }: ClinicInfoPanelProps) {
     const colour = waitTimeColour(clinic.estimatedWaitTime);
     const operatingHours = formatOperatingHours(clinic.hours);
-    const address = formatAddress(clinic);
     const mapsUrl = `https://www.google.com/maps/dir/?api=1&destination=${clinic.location.lat},${clinic.location.lng}`;
+
+    // use hook to get address
+    const { address, loading: addressLoading} = useClinicAddress(clinic);
 
     // calc distance display
     const distanceKm =
@@ -135,8 +132,8 @@ export default function ClinicInfoPanel({
                             </Text>
                         </Group>
                     )}
-                    <Stack gap="md">
 
+                    <Stack gap="md">
                     {/* Address */}
                     <Group gap="sm" align="flex-start">
                         <IconMapPin size={20} style={{marginTop: 2, flexShrink: 0}}/>
@@ -144,9 +141,13 @@ export default function ClinicInfoPanel({
                             <Text size="sm" fw={600} mb={2}>
                                 Address
                             </Text>
-                            <Text size="sm" c="dimmed">
-                                {address}
-                            </Text>
+                            {addressLoading ? (
+                                <Skeleton height={40} radius={"sm"} />
+                            ) : (
+                                <Text size="sm" c="dimmed">
+                                    {address|| "Address not available"}
+                                </Text>
+                            )}
                         </Box>
                     </Group>
 

--- a/frontend/src/app/components/clinic/clinic-list.tsx
+++ b/frontend/src/app/components/clinic/clinic-list.tsx
@@ -1,116 +1,124 @@
 import {
-  ActionIcon,
-  Group,
-  Input,
-  NativeSelect,
-  Popover,
-  ScrollArea,
-  Stack,
-  Text,
+    ActionIcon,
+    Group,
+    Input,
+    NativeSelect,
+    Popover,
+    ScrollArea,
+    Stack,
+    Text,
 } from "@mantine/core";
 
-import { useState } from "react";
-import { SearchIcon } from "@/icons/search-icon";
-import { FilterIcon } from "@/icons/filter-icon";
-import { ChevronDownIcon } from "@/icons/chevron-down-icon";
-import ClinicCard, { ClinicCardSkeleton } from "@components/clinic/clinic-card";
+import {useState} from "react";
+import {SearchIcon} from "@/icons/search-icon";
+import {FilterIcon} from "@/icons/filter-icon";
+import {ChevronDownIcon} from "@/icons/chevron-down-icon";
+import ClinicCard, {ClinicCardSkeleton} from "@components/clinic/clinic-card";
 import ClinicInfoPanel from "@components/clinic/clinic-info";
-import { useClinicContext } from "@/context/clinic-context";
+import {useClinicContext} from "@/context/clinic-context";
 import {Clinic} from "@models/clinic";
 
-export default function ClinicList() {
-  const [selectedType, setSelectedType] = useState<string>("All");
-  const [selectedClinic, setSelectedClinic] = useState<Clinic | null>(null);
-  const { clinics, loading, error, searchTerm, updateSearchTerm } =
-    useClinicContext();
+interface ClinicListProps {
+  selectedClinic?: Clinic | null;
+  onClinicSelect?: (clinic: Clinic) => void;
+}
 
-  const filteredClinics =
-    selectedType === "All"
-      ? clinics
-      : clinics.filter((clinic) => clinic.type === selectedType);
+export default function ClinicList({selectedClinic, onClinicSelect}: ClinicListProps) {
+    const [selectedType, setSelectedType] = useState<string>("All");
+    const {clinics, loading, error, searchTerm, updateSearchTerm} =
+        useClinicContext();
 
-  const handleMoreInfoClick = (clinic: Clinic) => {
-    setSelectedClinic(clinic);
-  };
+    const filteredClinics =
+        selectedType === "All"
+            ? clinics
+            : clinics.filter((clinic) => clinic.type === selectedType);
 
-  const handleBackToList = () => {
-    setSelectedClinic(null);
-  };
+    const handleMoreInfoClick = (clinic: Clinic) => {
+        if (onClinicSelect) {
+            onClinicSelect(clinic);
+        }
+    };
 
-  // show info panel if a clinic is selected
-  if (selectedClinic) {
+    const handleBackToList = () => {
+        if (onClinicSelect) {
+            onClinicSelect(null);
+        }
+    };
+
+    // show info panel if a clinic is selected
+    if (selectedClinic) {
+        return (
+            <ClinicInfoPanel
+                clinic={selectedClinic}
+                onBack={handleBackToList}
+            />
+        );
+    }
     return (
-        <ClinicInfoPanel
-            clinic={selectedClinic}
-            onBack={handleBackToList}
-        />
+        <Stack h="90vh" maw={450} mx="auto">
+            <Input
+                placeholder="Search clinics by name"
+                value={searchTerm}
+                onChange={(e) => updateSearchTerm(e.currentTarget.value)}
+                rightSectionPointerEvents="all"
+                rightSection={
+                    <ActionIcon variant="transparent" size="lg">
+                        <SearchIcon/>
+                    </ActionIcon>
+                }
+            />
+
+            {/* Filter and Type Select */}
+            <Group justify="space-between" align="center">
+                <Popover width={300} trapFocus position="bottom" withArrow shadow="md">
+                    <Popover.Target>
+                        <ActionIcon variant="transparent">
+                            <FilterIcon/>
+                        </ActionIcon>
+                    </Popover.Target>
+                    <Popover.Dropdown>
+                        <Text>test filter options</Text>
+                    </Popover.Dropdown>
+                </Popover>
+
+                <NativeSelect
+                    rightSection={<ChevronDownIcon size={16}/>}
+                    data={["All", "Clinic", "Hospital", "Urgent Care"]}
+                    value={selectedType}
+                    onChange={(event) => setSelectedType(event.currentTarget.value)}
+                />
+            </Group>
+
+            {/* Clinics List */}
+            {loading ? (
+                <ScrollArea>
+                    <Stack>
+                        {Array(3)
+                            .fill(0)
+                            .map((_, index) => (
+                                <ClinicCardSkeleton key={index}/>
+                            ))}
+                    </Stack>
+                </ScrollArea>
+            ) : error ? (
+                <Text>{error}</Text>
+            ) : (
+                <ScrollArea>
+                    <Stack>
+                        {filteredClinics.length > 0 ? (
+                            filteredClinics.map((clinic) => (
+                                <ClinicCard
+                                    key={clinic.id}
+                                    clinic={clinic}
+                                    onMoreInfoClick={handleMoreInfoClick}
+                                />
+                            ))
+                        ) : (
+                            <Text>No medical facilities found in this area.</Text>
+                        )}
+                    </Stack>
+                </ScrollArea>
+            )}
+        </Stack>
     );
-  }
-  return (
-      <Stack h="90vh" maw={450} mx="auto">
-        <Input
-          placeholder="Search clinics by name"
-          value={searchTerm}
-          onChange={(e) => updateSearchTerm(e.currentTarget.value)}
-          rightSectionPointerEvents="all"
-          rightSection={
-            <ActionIcon variant="transparent" size="lg">
-              <SearchIcon />
-            </ActionIcon>
-          }
-        />
-
-        {/* Filter and Type Select */}
-        <Group justify="space-between" align="center">
-          <Popover width={300} trapFocus position="bottom" withArrow shadow="md">
-            <Popover.Target>
-              <ActionIcon variant="transparent">
-                <FilterIcon />
-              </ActionIcon>
-            </Popover.Target>
-            <Popover.Dropdown>
-              <Text>test filter options</Text>
-            </Popover.Dropdown>
-          </Popover>
-
-          <NativeSelect
-            rightSection={<ChevronDownIcon size={16} />}
-            data={["All", "Clinic", "Hospital", "Urgent Care"]}
-            value={selectedType}
-            onChange={(event) => setSelectedType(event.currentTarget.value)}
-          />
-        </Group>
-
-        {/* Clinics List */}
-        {loading ? (
-          <ScrollArea>
-            <Stack>
-              {Array(3)
-                .fill(0)
-                .map((_, index) => (
-                  <ClinicCardSkeleton key={index} />
-                ))}
-            </Stack>
-          </ScrollArea>
-        ) : error ? (
-          <Text>{error}</Text>
-        ) : (
-          <ScrollArea>
-            <Stack>
-              {filteredClinics.length > 0 ? (
-                filteredClinics.map((clinic) => (
-                  <ClinicCard
-                      key={clinic.id}
-                      clinic={clinic}
-                      onMoreInfoClick={handleMoreInfoClick}
-                  />
-                ))
-              ) : (
-                <Text>No medical facilities found in this area.</Text>
-              )}
-            </Stack>
-          </ScrollArea>
-        )}
-      </Stack>
-  );
 }

--- a/frontend/src/app/components/clinic/clinic-list.tsx
+++ b/frontend/src/app/components/clinic/clinic-list.tsx
@@ -14,10 +14,13 @@ import { SearchIcon } from "@/icons/search-icon";
 import { FilterIcon } from "@/icons/filter-icon";
 import { ChevronDownIcon } from "@/icons/chevron-down-icon";
 import ClinicCard, { ClinicCardSkeleton } from "@components/clinic/clinic-card";
+import ClinicInfoPanel from "@components/clinic/clinic-info";
 import { useClinicContext } from "@/context/clinic-context";
+import {Clinic} from "@models/clinic";
 
 export default function ClinicList() {
   const [selectedType, setSelectedType] = useState<string>("All");
+  const [selectedClinic, setSelectedClinic] = useState<Clinic | null>(null);
   const { clinics, loading, error, searchTerm, updateSearchTerm } =
     useClinicContext();
 
@@ -26,67 +29,88 @@ export default function ClinicList() {
       ? clinics
       : clinics.filter((clinic) => clinic.type === selectedType);
 
-  return (
-    <Stack h="90vh" maw={450} mx="auto">
-      <Input
-        placeholder="Search clinics by name"
-        value={searchTerm}
-        onChange={(e) => updateSearchTerm(e.currentTarget.value)}
-        rightSectionPointerEvents="all"
-        rightSection={
-          <ActionIcon variant="transparent" size="lg">
-            <SearchIcon />
-          </ActionIcon>
-        }
-      />
+  const handleMoreInfoClick = (clinic: Clinic) => {
+    setSelectedClinic(clinic);
+  };
 
-      {/* Filter and Type Select */}
-      <Group justify="space-between" align="center">
-        <Popover width={300} trapFocus position="bottom" withArrow shadow="md">
-          <Popover.Target>
-            <ActionIcon variant="transparent">
-              <FilterIcon />
-            </ActionIcon>
-          </Popover.Target>
-          <Popover.Dropdown>
-            <Text>test filter options</Text>
-          </Popover.Dropdown>
-        </Popover>
+  const handleBackToList = () => {
+    setSelectedClinic(null);
+  };
 
-        <NativeSelect
-          rightSection={<ChevronDownIcon size={16} />}
-          data={["All", "Clinic", "Hospital", "Urgent Care"]}
-          value={selectedType}
-          onChange={(event) => setSelectedType(event.currentTarget.value)}
+  // show info panel if a clinic is selected
+  if (selectedClinic) {
+    return (
+        <ClinicInfoPanel
+            clinic={selectedClinic}
+            onBack={handleBackToList}
         />
-      </Group>
+    );
+  }
+  return (
+      <Stack h="90vh" maw={450} mx="auto">
+        <Input
+          placeholder="Search clinics by name"
+          value={searchTerm}
+          onChange={(e) => updateSearchTerm(e.currentTarget.value)}
+          rightSectionPointerEvents="all"
+          rightSection={
+            <ActionIcon variant="transparent" size="lg">
+              <SearchIcon />
+            </ActionIcon>
+          }
+        />
 
-      {/* Clinics List */}
-      {loading ? (
-        <ScrollArea>
-          <Stack>
-            {Array(3)
-              .fill(0)
-              .map((_, index) => (
-                <ClinicCardSkeleton key={index} />
-              ))}
-          </Stack>
-        </ScrollArea>
-      ) : error ? (
-        <Text>{error}</Text>
-      ) : (
-        <ScrollArea>
-          <Stack>
-            {filteredClinics.length > 0 ? (
-              filteredClinics.map((clinic) => (
-                <ClinicCard key={clinic.id} clinic={clinic} />
-              ))
-            ) : (
-              <Text>No medical facilities found in this area.</Text>
-            )}
-          </Stack>
-        </ScrollArea>
-      )}
-    </Stack>
+        {/* Filter and Type Select */}
+        <Group justify="space-between" align="center">
+          <Popover width={300} trapFocus position="bottom" withArrow shadow="md">
+            <Popover.Target>
+              <ActionIcon variant="transparent">
+                <FilterIcon />
+              </ActionIcon>
+            </Popover.Target>
+            <Popover.Dropdown>
+              <Text>test filter options</Text>
+            </Popover.Dropdown>
+          </Popover>
+
+          <NativeSelect
+            rightSection={<ChevronDownIcon size={16} />}
+            data={["All", "Clinic", "Hospital", "Urgent Care"]}
+            value={selectedType}
+            onChange={(event) => setSelectedType(event.currentTarget.value)}
+          />
+        </Group>
+
+        {/* Clinics List */}
+        {loading ? (
+          <ScrollArea>
+            <Stack>
+              {Array(3)
+                .fill(0)
+                .map((_, index) => (
+                  <ClinicCardSkeleton key={index} />
+                ))}
+            </Stack>
+          </ScrollArea>
+        ) : error ? (
+          <Text>{error}</Text>
+        ) : (
+          <ScrollArea>
+            <Stack>
+              {filteredClinics.length > 0 ? (
+                filteredClinics.map((clinic) => (
+                  <ClinicCard
+                      key={clinic.id}
+                      clinic={clinic}
+                      onMoreInfoClick={handleMoreInfoClick}
+                  />
+                ))
+              ) : (
+                <Text>No medical facilities found in this area.</Text>
+              )}
+            </Stack>
+          </ScrollArea>
+        )}
+      </Stack>
   );
 }

--- a/frontend/src/app/components/clinic/clinic-map.tsx
+++ b/frontend/src/app/components/clinic/clinic-map.tsx
@@ -19,6 +19,11 @@ import {
   IconUserFilled
 } from "@tabler/icons-react";
 import { GeolocationControl } from './geolocation-control';
+import { Clinic } from "@/models/clinic";
+
+interface ClinicMapProps {
+  onClinicSelect?: (clinic: Clinic) => void;
+}
 
 function MapEventHandler() {
   const { updateMapBounds } = useClinicContext();
@@ -74,7 +79,7 @@ function AutoCenterOnUser() {
   return null;
 }
 
-function ClinicMap() {
+function ClinicMap({onClinicSelect}:ClinicMapProps) {
   const { clinics, userLocation } = useClinicContext();
   const { colorScheme } = useMantineColorScheme();
 
@@ -118,6 +123,14 @@ function ClinicMap() {
     36, 18, 36
   );
 
+  const handleMarkerClick = (clinic: Clinic) => {
+    setSelectedClinic(clinic.id);
+    // call the parent callback to open the info panel
+    if (onClinicSelect) {
+      onClinicSelect(clinic);
+    }
+  };
+
   return (
     <>
       <MapContainer
@@ -148,9 +161,7 @@ function ClinicMap() {
             }
             icon={selectedClinic === clinic.id ? selectedIcon : clinicIcon}
             eventHandlers={{
-              click: () => {
-                setSelectedClinic(clinic.id);
-              },
+              click: () => handleMarkerClick(clinic),
             }}
           >
             <Popup>

--- a/frontend/src/app/models/clinic.ts
+++ b/frontend/src/app/models/clinic.ts
@@ -34,5 +34,6 @@ export interface Clinic {
   contact?: {
     phone?: string;
     email?: string;
+    website?: string;
   };
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,6 +7,8 @@ import {ClinicProvider} from "@/context/clinic-context";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import {ThemeLogo} from "@/components/ui/ThemeLogo";
+import { Clinic } from "@/models/clinic";
+import {useState} from "react";
 
 const ClinicMap = dynamic(() => import("@/components/clinic/clinic-map"), {
     ssr: false,
@@ -15,6 +17,11 @@ const ClinicMap = dynamic(() => import("@/components/clinic/clinic-map"), {
 
 function App() {
     const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+    const [selectedClinic, setSelectedClinic] = useState<Clinic | null>(null);
+
+    const handleClinicSelect = (clinic: Clinic | null) => {
+        setSelectedClinic(clinic);
+    };
 
     return (
         <ClinicProvider>
@@ -42,10 +49,15 @@ function App() {
 
                 <AppShell.Main className="main-container">
                     <div className="sidebar">
-                        <ClinicList />
+                        <ClinicList
+                            selectedClinic ={selectedClinic}
+                            onClinicSelect ={handleClinicSelect}
+                        />
                     </div>
                     <div className="map-container">
-                        <ClinicMap />
+                        <ClinicMap
+                            onClinicSelect ={handleClinicSelect}
+                        />
                     </div>
                 </AppShell.Main>
 

--- a/frontend/src/app/services/overpass-api.ts
+++ b/frontend/src/app/services/overpass-api.ts
@@ -75,9 +75,21 @@ export async function fetchMedicalFacilities(bounds: [number, number, number, nu
   }
 }
 
+function normalizeWebsite(url?: string): string | undefined {
+    if (!url) return undefined;
+
+    // add protocol if missing
+    if (url && !url.startsWith('http://') && !url.startsWith('https://')) {
+        return `https://${url}`;
+    }
+
+    return url;
+}
+
 function parseContact(tags: Record<string, string>) {
   const phone = tags.phone ?? tags["contact:phone"];
   const email = tags.email ?? tags["contact:email"];
+  const website = normalizeWebsite(tags.website ?? tags["contact:website"]);
   return phone || email ? { phone, email } : undefined;
 }
 
@@ -130,12 +142,13 @@ function transformOverpassData(data: any): Clinic[] {
         type,
         name,
         isOpen: true,
-        distance: "N/A",
+        distance: undefined,
         closingTime: hours ?? "Unknown",
         estimatedWaitTime: "N/A",
         services,
         hours,
         contact,
+        tags: t,
         location: lat != null ? { lat, lng } : { lat: 0, lng: 0 },
       } as Clinic;
     });

--- a/frontend/src/app/utils/address.ts
+++ b/frontend/src/app/utils/address.ts
@@ -1,0 +1,115 @@
+// Reverse geocode utility to generate an address from a coordinate
+// - uses Nominatim (OpenStreetMap) free reverse geocoding service
+// - For more info: https://nominatim.org/release-docs/latest/api/Reverse/
+
+import { useState, useEffect } from 'react';
+import { Clinic } from '@/models/clinic';
+
+export async function reverseGeocode(lat: number, lng: number): Promise<string> {
+    try {
+        const response = await fetch(
+            `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&zoom=18&addressdetails=1`,
+            {
+                headers: {
+                    'User-Agent': 'MediQ App'
+                }
+            }
+        );
+
+        if (!response.ok) {
+            throw new Error('Geocoding failed');
+        }
+
+        const data = await response.json();
+
+        // always construct address from components to avoid business names
+        //  - as business names are already shown at the top of panel
+        const addr = data.address;
+        if (addr) {
+            const parts = [];
+
+            // street address (house number + street name)
+            const streetParts = [addr.house_number, addr.road].filter(Boolean);
+            if (streetParts.length > 0) {
+                parts.push(streetParts.join(' '));
+            }
+
+            // unit/Suite/Apartment number (if available)
+            if (addr.unit || addr.suite || addr['addr:unit']) {
+                const unit = addr.unit || addr.suite || addr['addr:unit'];
+                if (parts.length > 0) {
+                    parts[0] = `${parts[0]}, Unit ${unit}`;
+                }
+            }
+
+            // city (prioritize city, fallback to town/village)
+            const city = addr.city || addr.town || addr.village;
+            if (city) {
+                parts.push(city);
+            }
+
+            // state/province
+            if (addr.state) {
+                parts.push(addr.state);
+            }
+
+            // postal code
+            if (addr.postcode) {
+                parts.push(addr.postcode);
+            }
+
+            if (parts.length > 0) {
+                return parts.join(', ');
+            }
+        }
+
+        // fallback if no structured address is available
+        if (data.display_name) {
+            // try to extract meaningful parts from display_name as last resort
+            const displayParts = data.display_name.split(', ');
+            // skip the first part (likely business name) and take relevant address components
+            const relevantParts = displayParts.slice(1, 5).filter(part =>
+                !part.includes('Golden Horseshoe') &&
+                !part.includes('Centre') &&
+                !part.includes('Park') &&
+                part.length > 1
+            );
+            if (relevantParts.length > 0) {
+                return relevantParts.join(', ');
+            }
+        }
+
+        throw new Error('No address found');
+    } catch (error) {
+        console.error('Reverse geocoding error:', error);
+        return `Coordinates: ${lat.toFixed(4)}, ${lng.toFixed(4)}`;
+    }
+}
+
+// clinic type with cached address
+export interface ClinicWithAddress extends Clinic {
+    formattedAddress: string;
+    addressLoading?: boolean;
+}
+
+// hook to manage address fetching for a clinic
+export function useClinicAddress(clinic: Clinic) {
+    const [address, setAddress] = useState<string>('');
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (clinic.location?.lat && clinic.location?.lng) {
+            setLoading(true);
+            reverseGeocode(clinic.location.lat, clinic.location.lng)
+                .then(setAddress)
+                .catch((error) => {
+                    console.error('Failed to get address:', error);
+                    setAddress(`Coordinates: ${clinic.location.lat.toFixed(4)}, ${clinic.location.lng.toFixed(4)}`);
+                })
+                .finally(() => setLoading(false));
+        }
+    }, [clinic.location?.lat, clinic.location?.lng]);
+
+    return { address, loading };
+}
+


### PR DESCRIPTION
**Changes:** 
- Implemented "More Info" button to open detailed view of each location when button is clicked. 
-- Should show Name, Location Type, Operating Hours, Website, and Phone
-- Also Current Wait Time. Buttons to _suggest time_ and _get directions_ is also available here 
- Updated components so that selected location via map pin opens detailed view in the Panel
-- instead of it only being accessible through the More Info button.  
- Removed location contact info from clinic card, and moved to More Info Panel. 
- Created reverse geocode utility to generate an address from a coordinate. This should now show the address in the More info Panel. 
-- No address were showing per location previously. 
-- This uses OpenStreetMap's Noninatim Reverse Geocoding Service 
     (check link for more info: https://nominatim.org/release-docs/latest/api/Reverse/)

**NOTE**: Unfortunately, I was unable to properly implement Operating Hours per location. Currently, OpenStreetMap's data on certain facilities is limited, partly being open-sourced. It may not have received many volunteers to input these data. 
This also applies to contact information on certain locations. Some locations do not have the website, phone number, or street numbers.
With this in mind, I took off the option for closing time in the clinic card as it would have been stuck on "Closes at Unknown" otherwise. Also added a generic message for operating hours. Small note also changes depending on location type.

<img width="1597" height="1183" alt="image" src="https://github.com/user-attachments/assets/aeceb147-e58f-4d40-a8bb-06b64bea5ad3" />
<img width="1610" height="1175" alt="image" src="https://github.com/user-attachments/assets/50b0e188-6029-4c1a-999c-599abe90cd99" />
<img width="557" height="972" alt="image" src="https://github.com/user-attachments/assets/3921768b-d3c4-4cbe-adcd-27d790a1fe42" />

Completes #18 
