### PR TITLE
FIX: Operating Hours logic and inaccurate open/closed badge 

### DIFF
--- a/frontend/src/app/components/clinic/clinic-card.tsx
+++ b/frontend/src/app/components/clinic/clinic-card.tsx
@@ -18,32 +18,33 @@ import {
   IconUserPin,
 } from "@tabler/icons-react";
 import { Clinic } from "@/models/clinic";
+import { determineOpenStatus, extractClosingTime } from "@/utils/time";
 
 /* ─────────────────────────── Skeleton ─────────────────────────── */
 export function ClinicCardSkeleton() {
   return (
-    <Card shadow="sm" p="lg" radius="md" miw={436} withBorder>
-      <Card.Section>
-        <Group justify="flex-start" align="center" p="md">
-          <Skeleton height={20} width={62} radius="sm" />
-          <Skeleton height={20} width={62} radius="sm" />
-        </Group>
-      </Card.Section>
+      <Card shadow="sm" p="lg" radius="md" miw={436} withBorder>
+        <Card.Section>
+          <Group justify="flex-start" align="center" p="md">
+            <Skeleton height={20} width={62} radius="sm" />
+            <Skeleton height={20} width={62} radius="sm" />
+          </Group>
+        </Card.Section>
 
-      <Group justify="space-between" mb="xs">
-        <Skeleton height={25} width={150} radius="sm" />
-        <Skeleton height={20} width={42} radius="sm" />
-      </Group>
-      <Stack gap="0">
-        <Skeleton height={24} width="70%" radius="sm" />
-        <Skeleton height={24} width="60%" radius="sm" />
-      </Stack>
-      <Group>
-        <Skeleton height={36} width={100} mt="md" radius="md" />
-        <Skeleton height={36} width={100} mt="md" radius="md" />
-        <Skeleton height={36} width={100} mt="md" radius="md" />
-      </Group>
-    </Card>
+        <Group justify="space-between" mb="xs">
+          <Skeleton height={25} width={150} radius="sm" />
+          <Skeleton height={20} width={42} radius="sm" />
+        </Group>
+        <Stack gap="0">
+          <Skeleton height={24} width="70%" radius="sm" />
+          <Skeleton height={24} width="60%" radius="sm" />
+        </Stack>
+        <Group>
+          <Skeleton height={36} width={100} mt="md" radius="md" />
+          <Skeleton height={36} width={100} mt="md" radius="md" />
+          <Skeleton height={36} width={100} mt="md" radius="md" />
+        </Group>
+      </Card>
   );
 }
 
@@ -64,100 +65,109 @@ interface ClinicCardProps {
 
 export default function ClinicCard({ clinic, onMoreInfoClick }: ClinicCardProps) {
   const distanceKm =
-    clinic.distance != null && typeof clinic.distance === "number"
-      ? (clinic.distance / 1000).toFixed(2)
-      : clinic.distance; // fallback to string
+      clinic.distance != null && typeof clinic.distance === "number"
+          ? (clinic.distance / 1000).toFixed(2)
+          : clinic.distance; // fallback to string
 
   const colour = waitTimeColour(clinic.estimatedWaitTime);
   const mapsUrl = `https://www.google.com/maps/dir/?api=1&destination=${clinic.location.lat},${clinic.location.lng}`;
 
+  // get accurate open/closed status and closing time
+  const { isOpen, hasData } = determineOpenStatus(clinic.hours);
+  const closingTime = extractClosingTime(clinic.hours);
+
   return (
-    <Card shadow="sm" p="lg" radius="md" miw={450} withBorder>
-      {/* ── Labels ─────────────────────────────────────────────── */}
-      <Card.Section>
-        <Group justify="flex-start" align="center" p="md">
-          <Badge color="blue" variant="light">
-            <Text size="xs" c="dimmed">
-              {clinic.type}
-            </Text>
-          </Badge>
-          <Badge color={clinic.isOpen ? "green" : "red"} variant="light">
-            <Text size="xs" c="dimmed">
-              {clinic.isOpen ? "OPEN" : "CLOSED"}
-            </Text>
-          </Badge>
-        </Group>
-      </Card.Section>
+      <Card shadow="sm" p="lg" radius="md" miw={450} withBorder>
+        {/* ── Labels ─────────────────────────────────────────────── */}
+        <Card.Section>
+          <Group justify="flex-start" align="center" p="md">
+            <Badge color="blue" variant="light">
+              <Text size="xs" c="dimmed">
+                {clinic.type}
+              </Text>
+            </Badge>
+            {/* only show open/closed badge if we have hours data */}
+            {hasData && (
+                <Badge color={isOpen ? "green" : "red"} variant="light">
+                  <Text size="xs" c="dimmed">
+                    {isOpen ? "OPEN" : "CLOSED"}
+                  </Text>
+                </Badge>
+            )}
+          </Group>
+        </Card.Section>
 
-      {/* ── Name + Wait-time badge ─────────────────────────────── */}
-      <Group justify="space-between" mb="xs">
-        <Text
-          className="montserrat-bold"
-          fz="lg"
-          style={{ flex: 1, minWidth: 0 }}
-          lineClamp={2}
-        >
-          {clinic.name}
-        </Text>
-
-        <Badge color={colour} style={{ flexShrink: 0, alignSelf: "center" }}>
-          {clinic.estimatedWaitTime}
-        </Badge>
-      </Group>
-
-      {/* ── Distance & Closing Time ────────────────────────────── */}
-      <Stack gap={2}>
-        <Group gap="xs">
-          <IconUserPin size={16} />
-          <Text size="sm">
-            {distanceKm ? `${distanceKm} km away from you` : "Distance unknown"}
+        {/* ── Name + Wait-time badge ─────────────────────────────── */}
+        <Group justify="space-between" mb="xs">
+          <Text
+              className="montserrat-bold"
+              fz="lg"
+              style={{ flex: 1, minWidth: 0 }}
+              lineClamp={2}
+          >
+            {clinic.name}
           </Text>
+
+          <Badge color={colour} style={{ flexShrink: 0, alignSelf: "center" }}>
+            {clinic.estimatedWaitTime}
+          </Badge>
         </Group>
-        {/*Commenting out for the time being. Unable to add operating hours at this time. */}
-        {/*<Group gap="xs">*/}
-        {/*  <IconClockHour2 size={16} />*/}
-        {/*  <Text size="sm">Closes at {clinic.closingTime}</Text>*/}
-        {/*</Group>*/}
-      </Stack>
 
-      {/* ── Buttons ────────────────────────────────────────────── */}
-      <Group justify="center" mt="md">
-        <Button
-          color="blue"
-          radius="md"
-          h={60}
-          w={125}
-          p="xs"
-          component="a"
-          href={mapsUrl}
-          target="_blank"
-        >
-          <Stack gap={4} align="center">
-            <IconMapPin2 size={20} />
-            <Text className="montserrat-med" size="xs">
-              DIRECTIONS
+        {/* ── Distance & Closing Time ────────────────────────────── */}
+        <Stack gap={2}>
+          <Group gap="xs">
+            <IconUserPin size={16} />
+            <Text size="sm">
+              {distanceKm ? `${distanceKm} km away from you` : "Distance unknown"}
             </Text>
-          </Stack>
-        </Button>
+          </Group>
+          {/* only show closing time if we have valid data */}
+          {closingTime && (
+              <Group gap="xs">
+                <IconClockHour2 size={16} />
+                <Text size="sm">Closes at {closingTime}</Text>
+              </Group>
+          )}
+        </Stack>
 
-        <Button color="blue" radius="md" h={60} w={125} p="xs">
-          <Stack gap={4} align="center">
-            <IconHourglassEmpty size={20} />
-            <Text className="montserrat-med" size="xs">
-              SUGGEST&nbsp;TIME
-            </Text>
-          </Stack>
-        </Button>
+        {/* ── Buttons ────────────────────────────────────────────── */}
+        <Group justify="center" mt="md">
+          <Button
+              color="blue"
+              radius="md"
+              h={60}
+              w={125}
+              p="xs"
+              component="a"
+              href={mapsUrl}
+              target="_blank"
+          >
+            <Stack gap={4} align="center">
+              <IconMapPin2 size={20} />
+              <Text className="montserrat-med" size="xs">
+                DIRECTIONS
+              </Text>
+            </Stack>
+          </Button>
 
-        <Button color="blue" radius="md" h={60} w={125} p="xs" onClick={() => onMoreInfoClick(clinic)}>
-          <Stack gap={4} align="center">
-            <IconInfoCircle size={20} />
-            <Text className="montserrat-med" size="xs">
-              MORE&nbsp;INFO
-            </Text>
-          </Stack>
-        </Button>
-      </Group>
-    </Card>
+          <Button color="blue" radius="md" h={60} w={125} p="xs">
+            <Stack gap={4} align="center">
+              <IconHourglassEmpty size={20} />
+              <Text className="montserrat-med" size="xs">
+                SUGGEST&nbsp;TIME
+              </Text>
+            </Stack>
+          </Button>
+
+          <Button color="blue" radius="md" h={60} w={125} p="xs" onClick={() => onMoreInfoClick(clinic)}>
+            <Stack gap={4} align="center">
+              <IconInfoCircle size={20} />
+              <Text className="montserrat-med" size="xs">
+                MORE&nbsp;INFO
+              </Text>
+            </Stack>
+          </Button>
+        </Group>
+      </Card>
   );
 }

--- a/frontend/src/app/components/clinic/clinic-info.tsx
+++ b/frontend/src/app/components/clinic/clinic-info.tsx
@@ -24,6 +24,7 @@ import {
 } from "@tabler/icons-react";
 import { Clinic } from "@/models/clinic";
 import { useClinicAddress } from "@/utils/address";
+import { convertTimeRangeTo12Hour, determineOpenStatus, parseOpeningHours } from "@/utils/time";
 
 interface ClinicInfoPanelProps {
     clinic: Clinic;
@@ -38,107 +39,30 @@ function waitTimeColour(wt: string) {
     return "red";
 }
 
-function parseOpeningHours(hours?: string) {
-    if (!hours || hours === "N/A" || hours === "Unknown" || hours.trim() === "") {
-        return null;
-    }
-
-    try {
-        const daysMap: { [key: string]: string } = {
-            'Mo': 'Monday',
-            'Tu': 'Tuesday',
-            'We': 'Wednesday',
-            'Th': 'Thursday',
-            'Fr': 'Friday',
-            'Sa': 'Saturday',
-            'Su': 'Sunday'
-        };
-
-        // handle simple formats like "Mo-Fr 09:00-17:00" or "24/7"
-        if (hours === "24/7") {
-            const daySchedule = { day: "Every day", hours: "24 hours" };
-            return Array(7).fill(0).map((_, i) => ({
-                day: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][i],
-                hours: "24 hours"
-            }));
-        }
-
-        // handle "Mo-Fr HH:MM-HH:MM" format
-        const weekdayPattern = /^Mo-Fr\s+(\d{1,2}):(\d{2})-(\d{1,2}):(\d{2})$/;
-        const weekdayMatch = hours.match(weekdayPattern);
-        if (weekdayMatch) {
-            const [, startHour, startMin, endHour, endMin] = weekdayMatch;
-            const timeStr = `${startHour}:${startMin} - ${endHour}:${endMin}`;
-            return [
-                { day: "Monday", hours: timeStr },
-                { day: "Tuesday", hours: timeStr },
-                { day: "Wednesday", hours: timeStr },
-                { day: "Thursday", hours: timeStr },
-                { day: "Friday", hours: timeStr },
-                { day: "Saturday", hours: "Closed" },
-                { day: "Sunday", hours: "Closed" },
-            ];
-        }
-
-        // handle "Mo-Su HH:MM-HH:MM" format
-        const allDaysPattern = /^Mo-Su\s+(\d{1,2}):(\d{2})-(\d{1,2}):(\d{2})$/;
-        const allDaysMatch = hours.match(allDaysPattern);
-        if (allDaysMatch) {
-            const [, startHour, startMin, endHour, endMin] = allDaysMatch;
-            const timeStr = `${startHour}:${startMin} - ${endHour}:${endMin}`;
-            return Array(7).fill(0).map((_, i) => ({
-                day: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][i],
-                hours: timeStr
-            }));
-        }
-
-        // if it looks like a simple time range, apply to all days
-        const timePattern = /^\d{1,2}:\d{2}-\d{1,2}:\d{2}$/;
-        if (timePattern.test(hours)) {
-            return Array(7).fill(0).map((_, i) => ({
-                day: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][i],
-                hours: hours
-            }));
-        }
-
-        // fallback: return the raw hours string for each day
-        return Array(7).fill(0).map((_, i) => ({
-            day: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][i],
-            hours: hours
-        }));
-
-    } catch (error) {
-        console.error('Error parsing opening hours:', error);
-        return null;
-    }
-}
-
 function formatOperatingHours(hours?: string) {
     const parsed = parseOpeningHours(hours);
 
     if (parsed) {
-        return parsed;
+        // convert to 12-hour format
+        return parsed.map(schedule => ({
+            ...schedule,
+            hours: convertTimeRangeTo12Hour(schedule.hours)
+        }));
     }
 
-    // fallback
-    return [
-        { day: "Monday", hours: "Hours not available" },
-        { day: "Tuesday", hours: "Hours not available" },
-        { day: "Wednesday", hours: "Hours not available" },
-        { day: "Thursday", hours: "Hours not available" },
-        { day: "Friday", hours: "Hours not available" },
-        { day: "Saturday", hours: "Hours not available" },
-        { day: "Sunday", hours: "Hours not available" },
-    ];
+    return null;
 }
 
 export default function ClinicInfoPanel({
-    clinic,
-    onBack,
-}: ClinicInfoPanelProps) {
+                                            clinic,
+                                            onBack,
+                                        }: ClinicInfoPanelProps) {
     const colour = waitTimeColour(clinic.estimatedWaitTime);
     const operatingHours = formatOperatingHours(clinic.hours);
     const mapsUrl = `https://www.google.com/maps/dir/?api=1&destination=${clinic.location.lat},${clinic.location.lng}`;
+
+    // get accurate open/closed status
+    const { isOpen, hasData } = determineOpenStatus(clinic.hours);
 
     // use hook to get address
     const { address, loading: addressLoading} = useClinicAddress(clinic);
@@ -182,15 +106,18 @@ export default function ClinicInfoPanel({
                                 {clinic.type}
                             </Text>
                         </Badge>
-                        <Badge
-                            color={clinic.isOpen ? "green" : "red"}
-                            variant="light"
-                            size="lg"
-                        >
-                            <Text size="sm" tt="uppercase">
-                                {clinic.isOpen ? "Open Now" : "Closed"}
-                            </Text>
-                        </Badge>
+                        {/* only show open/closed badge if we have hours data */}
+                        {hasData && (
+                            <Badge
+                                color={isOpen ? "green" : "red"}
+                                variant="light"
+                                size="lg"
+                            >
+                                <Text size="sm" tt="uppercase">
+                                    {isOpen ? "Open Now" : "Closed"}
+                                </Text>
+                            </Badge>
+                        )}
                     </Group>
 
                     {/* Distance */}
@@ -203,171 +130,178 @@ export default function ClinicInfoPanel({
                     )}
 
                     <Stack gap="md">
-                    {/* Address */}
-                    <Group gap="sm" align="flex-start">
-                        <IconMapPin size={20} style={{marginTop: 2, flexShrink: 0}}/>
-                        <Box flex={1}>
-                            <Text size="sm" fw={600} mb={2}>
-                                Address
-                            </Text>
-                            {addressLoading ? (
-                                <Skeleton height={40} radius={"sm"} />
-                            ) : (
-                                <Text size="sm" c="dimmed">
-                                    {address|| "Address not available"}
+                        {/* Address */}
+                        <Group gap="sm" align="flex-start">
+                            <IconMapPin size={20} style={{marginTop: 2, flexShrink: 0}}/>
+                            <Box flex={1}>
+                                <Text size="sm" fw={600} mb={2}>
+                                    Address
                                 </Text>
-                            )}
-                        </Box>
-                    </Group>
-
-                    {/* Operating Hours */}
-                    <Group gap="sm" align="flex-start">
-                        <IconClock size={20} style={{marginTop: 2, flexShrink: 0}}/>
-                        <Box flex={1}>
-                            <Text size="sm" fw={600} mb={4}>
-                                Operating Hours
-                            </Text>
-                            <Stack gap={2}>
-                                <Text size="sm" c="orange" fw={500} mb={4}>
-                                    Coming Soon! Hours data not available from OpenStreetMap.
-                                </Text>
-                                <Group justify="space-between">
-                                    <Text size="sm">For current hours:</Text>
-                                    <Text size="sm" c="blue">Call facility directly</Text>
-                                </Group>
-                                <Group justify="space-between">
-                                    <Text size="sm">General hours:</Text>
-                                    <Text size="sm" c="dimmed">Varies by facility type</Text>
-                                </Group>
-                                <Box mt={8} p={8} style={{ background: '#f8f9fa', borderRadius: '4px' }}>
-                                    <Text size="xs" c="dimmed">
-                                        <strong>Note:</strong> {clinic.type === 'Hospital'
-                                        ? 'Emergency departments typically operate 24/7'
-                                        : clinic.type === 'Urgent Care'
-                                            ? 'Urgent care usually: 8AM-8PM daily'
-                                            : 'Walk-in clinics typically: 9AM-5PM weekdays'
-                                    }
+                                {addressLoading ? (
+                                    <Skeleton height={40} radius={"sm"} />
+                                ) : (
+                                    <Text size="sm" c="dimmed">
+                                        {address|| "Address not available"}
                                     </Text>
-                                </Box>
-                                {/*{operatingHours.map((schedule) => (*/}
-                                {/*    <Group justify="space-between" key={schedule.day}>*/}
-                                {/*        <Text size="sm">{schedule.day}</Text>*/}
-                                {/*        <Text size="sm" c="dimmed">{schedule.hours}</Text>*/}
-                                {/*    </Group>*/}
-                                {/*))}*/}
-                            </Stack>
-                        </Box>
-                    </Group>
-
-                    {/* Website */}
-                    <Group gap="sm" align="flex-start">
-                        <IconWorld size={20} style={{marginTop: 2, flexShrink: 0}}/>
-                        <Box flex={1}>
-                            <Text size="sm" fw={600} mb={2}>
-                                Website
-                            </Text>
-                            {clinic.contact?.website ||
-                            (clinic as any).website ||
-                            (clinic as any).tags?.website ||
-                            (clinic as any).tags?.["contact:website"] ? (
-                                <Text
-                                    size="sm"
-                                    c="blue"
-                                    component="a"
-                                    href={
-                                        clinic.contact?.website ||
-                                        (clinic as any).website ||
-                                        (clinic as any).tags?.website ||
-                                        (clinic as any).tags?.["contact:website"]
-                                    }
-                                    target="_blank"
-                                    style={{textDecoration: "underline"}}
-                                >
-                                    {(
-                                        clinic.contact?.website ||
-                                        (clinic as any).website ||
-                                        (clinic as any).tags?.website ||
-                                        (clinic as any).tags?.["contact:website"]
-                                    )?.replace(/^https?:\/\//, '')}
-                                </Text>
-                            ) : (
-                                <Text size="sm" c="dimmed">
-                                    Website is currently not available at this time.
-                                </Text>
-                            )}
-                        </Box>
-                    </Group>
-
-                    {/* Phone Number */}
-                    <Group gap="sm" align="flex-start">
-                        <IconPhone size={20} style={{marginTop: 2, flexShrink: 0}}/>
-                        <Box flex={1}>
-                            <Text size="sm" fw={600} mb={2}>
-                                Phone
-                            </Text>
-                            {clinic.contact?.phone && clinic.contact.phone !== "Not available" ? (
-                                <Text
-                                    size="sm"
-                                    c="blue"
-                                    component="a"
-                                    href={`tel:${clinic.contact.phone}`}
-                                    style={{textDecoration: "underline"}}
-                                >
-                                    {clinic.contact.phone}
-                                </Text>
-                            ) : (
-                                <Text size="sm" c="dimmed">
-                                    Phone number is currently not available at this time.
-                                </Text>
-                            )}
-                        </Box>
-                    </Group>
-
-                    <Divider my="md"/>
-
-                    {/* Current Wait Time */}
-                    <Box>
-                        <Text size="lg" fw={600} mb="sm">
-                            Current Wait Time:
-                        </Text>
-                        <Group justify="space-between" align="center">
-                            <Text size="sm">
-                                Currently at the Clinic?
-                            </Text>
-                            <Badge color={colour} size="xl" variant="filled">
-                                <Text size="lg" fw={700}>
-                                    {clinic.estimatedWaitTime}
-                                </Text>
-                            </Badge>
+                                )}
+                            </Box>
                         </Group>
-                    </Box>
 
-                    {/* Action Buttons */}
-                    <Stack gap="sm" mt="md">
-                        <Button
-                            color="blue"
-                            size="md"
-                            radius="md"
-                            leftSection={<IconHourglassEmpty size={20}/>}
-                        >
-                            Suggest Wait Time
-                        </Button>
-                        <Button
-                            color="blue"
-                            size="md"
-                            radius="md"
-                            variant="outline"
-                            leftSection={<IconMapPin2 size={20}/>}
-                            component="a"
-                            href={mapsUrl}
-                            target="_blank"
-                        >
-                            Get Directions
-                        </Button>
+                        {/* Operating Hours */}
+                        <Group gap="sm" align="flex-start">
+                            <IconClock size={20} style={{marginTop: 2, flexShrink: 0}}/>
+                            <Box flex={1}>
+                                <Text size="sm" fw={600} mb={4}>
+                                    Operating Hours
+                                </Text>
+                                <Stack gap={2}>
+                                    {operatingHours ? (
+                                        // show actual hours when available in 12-hour format
+                                        operatingHours.map((schedule) => (
+                                            <Group justify="space-between" key={schedule.day}>
+                                                <Text size="sm">{schedule.day}</Text>
+                                                <Text size="sm" c="dimmed">{schedule.hours}</Text>
+                                            </Group>
+                                        ))
+                                    ) : (
+                                        // show generic message only when no hours data is available
+                                        <>
+                                            <Text size="sm" c="orange" fw={500} mb={4}>
+                                                Coming Soon! Hours data not available from OpenStreetMap.
+                                            </Text>
+                                            <Group justify="space-between">
+                                                <Text size="sm">For current hours:</Text>
+                                                <Text size="sm" c="blue">Call facility directly</Text>
+                                            </Group>
+                                            <Group justify="space-between">
+                                                <Text size="sm">General hours:</Text>
+                                                <Text size="sm" c="dimmed">Varies by facility type</Text>
+                                            </Group>
+                                            <Box mt={8} p={8} style={{ background: '#f8f9fa', borderRadius: '4px' }}>
+                                                <Text size="xs" c="dimmed">
+                                                    <strong>Note:</strong> {clinic.type === 'Hospital'
+                                                    ? 'Emergency departments typically operate 24/7'
+                                                    : clinic.type === 'Urgent Care'
+                                                        ? 'Urgent care usually: 8AM-8PM daily'
+                                                        : 'Walk-in clinics typically: 9AM-5PM weekdays'
+                                                }
+                                                </Text>
+                                            </Box>
+                                        </>
+                                    )}
+                                </Stack>
+                            </Box>
+                        </Group>
+
+                        {/* Website */}
+                        <Group gap="sm" align="flex-start">
+                            <IconWorld size={20} style={{marginTop: 2, flexShrink: 0}}/>
+                            <Box flex={1}>
+                                <Text size="sm" fw={600} mb={2}>
+                                    Website
+                                </Text>
+                                {clinic.contact?.website ||
+                                (clinic as any).website ||
+                                (clinic as any).tags?.website ||
+                                (clinic as any).tags?.["contact:website"] ? (
+                                    <Text
+                                        size="sm"
+                                        c="blue"
+                                        component="a"
+                                        href={
+                                            clinic.contact?.website ||
+                                            (clinic as any).website ||
+                                            (clinic as any).tags?.website ||
+                                            (clinic as any).tags?.["contact:website"]
+                                        }
+                                        target="_blank"
+                                        style={{textDecoration: "underline"}}
+                                    >
+                                        {(
+                                            clinic.contact?.website ||
+                                            (clinic as any).website ||
+                                            (clinic as any).tags?.website ||
+                                            (clinic as any).tags?.["contact:website"]
+                                        )?.replace(/^https?:\/\//, '')}
+                                    </Text>
+                                ) : (
+                                    <Text size="sm" c="dimmed">
+                                        Website is currently not available at this time.
+                                    </Text>
+                                )}
+                            </Box>
+                        </Group>
+
+                        {/* Phone Number */}
+                        <Group gap="sm" align="flex-start">
+                            <IconPhone size={20} style={{marginTop: 2, flexShrink: 0}}/>
+                            <Box flex={1}>
+                                <Text size="sm" fw={600} mb={2}>
+                                    Phone
+                                </Text>
+                                {clinic.contact?.phone && clinic.contact.phone !== "Not available" ? (
+                                    <Text
+                                        size="sm"
+                                        c="blue"
+                                        component="a"
+                                        href={`tel:${clinic.contact.phone}`}
+                                        style={{textDecoration: "underline"}}
+                                    >
+                                        {clinic.contact.phone}
+                                    </Text>
+                                ) : (
+                                    <Text size="sm" c="dimmed">
+                                        Phone number is currently not available at this time.
+                                    </Text>
+                                )}
+                            </Box>
+                        </Group>
+
+                        <Divider my="md"/>
+
+                        {/* Current Wait Time */}
+                        <Box>
+                            <Text size="lg" fw={600} mb="sm">
+                                Current Wait Time:
+                            </Text>
+                            <Group justify="space-between" align="center">
+                                <Text size="sm">
+                                    Currently at the Clinic?
+                                </Text>
+                                <Badge color={colour} size="xl" variant="filled">
+                                    <Text size="lg" fw={700}>
+                                        {clinic.estimatedWaitTime}
+                                    </Text>
+                                </Badge>
+                            </Group>
+                        </Box>
+
+                        {/* Action Buttons */}
+                        <Stack gap="sm" mt="md">
+                            <Button
+                                color="blue"
+                                size="md"
+                                radius="md"
+                                leftSection={<IconHourglassEmpty size={20}/>}
+                            >
+                                Suggest Wait Time
+                            </Button>
+                            <Button
+                                color="blue"
+                                size="md"
+                                radius="md"
+                                variant="outline"
+                                leftSection={<IconMapPin2 size={20}/>}
+                                component="a"
+                                href={mapsUrl}
+                                target="_blank"
+                            >
+                                Get Directions
+                            </Button>
+                        </Stack>
                     </Stack>
                 </Stack>
-            </Stack>
-        </ScrollArea>
-    </Stack>
-);
+            </ScrollArea>
+        </Stack>
+    );
 }

--- a/frontend/src/app/utils/time.ts
+++ b/frontend/src/app/utils/time.ts
@@ -1,0 +1,340 @@
+// Time utility
+// - to convert 24 hour time functions to 12-hour format
+// - parse opening hours string into structured format (moved from clinic-info.tsx)
+// - extract closing time from hours
+// - determine if clinic is currently open based on operating hours
+// - convert time string to minutes since midnight
+
+
+// convert 24-hour time to 12-hour format
+export function convertTo12Hour(time24: string): string {
+    if (!time24 || !time24.includes(':')) {
+        return time24;
+    }
+
+    const [hours, minutes] = time24.split(':');
+    const hour = parseInt(hours);
+    const min = minutes;
+
+    if (isNaN(hour) || hour < 0 || hour > 23) {
+        return time24; // Return original if invalid
+    }
+
+    const ampm = hour >= 12 ? 'PM' : 'AM';
+    const hour12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+
+    return `${hour12}:${min} ${ampm}`;
+}
+
+// convert time range to 12-hour format
+export function convertTimeRangeTo12Hour(timeRange: string): string {
+    if (!timeRange || timeRange === 'Closed' || timeRange === '24 hours') {
+        return timeRange;
+    }
+
+    if (timeRange.includes('-')) {
+        const [start, end] = timeRange.split('-');
+        return `${convertTo12Hour(start.trim())} - ${convertTo12Hour(end.trim())}`;
+    }
+
+    return timeRange;
+}
+
+// parse opening hours string into structured format
+export function parseOpeningHours(hours?: string) {
+    if (!hours || hours === "N/A" || hours === "Unknown" || hours.trim() === "") {
+        return null;
+    }
+
+    try {
+        const daysMap: { [key: string]: string } = {
+            'Mo': 'Monday',
+            'Tu': 'Tuesday',
+            'We': 'Wednesday',
+            'Th': 'Thursday',
+            'Fr': 'Friday',
+            'Sa': 'Saturday',
+            'Su': 'Sunday'
+        };
+
+        // handle 24/7
+        if (hours === "24/7") {
+            return Array(7).fill(0).map((_, i) => ({
+                day: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][i],
+                hours: "24 hours"
+            }));
+        }
+
+        // handle "Mo-Fr HH:MM-HH:MM" format
+        const weekdayPattern = /^Mo-Fr\s+(\d{1,2}):(\d{2})-(\d{1,2}):(\d{2})$/;
+        const weekdayMatch = hours.match(weekdayPattern);
+        if (weekdayMatch) {
+            const [, startHour, startMin, endHour, endMin] = weekdayMatch;
+            const timeStr = `${startHour}:${startMin} - ${endHour}:${endMin}`;
+            return [
+                { day: "Monday", hours: timeStr },
+                { day: "Tuesday", hours: timeStr },
+                { day: "Wednesday", hours: timeStr },
+                { day: "Thursday", hours: timeStr },
+                { day: "Friday", hours: timeStr },
+                { day: "Saturday", hours: "Closed" },
+                { day: "Sunday", hours: "Closed" },
+            ];
+        }
+
+        // handle "Mo-Su HH:MM-HH:MM" format (all days same hours)
+        const allDaysPattern = /^Mo-Su\s+(\d{1,2}):(\d{2})-(\d{1,2}):(\d{2})$/;
+        const allDaysMatch = hours.match(allDaysPattern);
+        if (allDaysMatch) {
+            const [, startHour, startMin, endHour, endMin] = allDaysMatch;
+            const timeStr = `${startHour}:${startMin} - ${endHour}:${endMin}`;
+            return Array(7).fill(0).map((_, i) => ({
+                day: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][i],
+                hours: timeStr
+            }));
+        }
+
+        // handle semicolon-separated format like "Mo 09:00-17:00; Tu 09:00-17:00; We off"
+        if (hours.includes(';')) {
+            const schedule = [
+                { day: "Monday", hours: "Closed" },
+                { day: "Tuesday", hours: "Closed" },
+                { day: "Wednesday", hours: "Closed" },
+                { day: "Thursday", hours: "Closed" },
+                { day: "Friday", hours: "Closed" },
+                { day: "Saturday", hours: "Closed" },
+                { day: "Sunday", hours: "Closed" },
+            ];
+
+            const parts = hours.split(';');
+            parts.forEach(part => {
+                const trimmed = part.trim();
+
+                // handle day ranges like "Mo-Fr 09:00-17:00"
+                const rangePattern = /^(Mo|Tu|We|Th|Fr|Sa|Su)-(Mo|Tu|We|Th|Fr|Sa|Su)\s+(.+)$/;
+                const rangeMatch = trimmed.match(rangePattern);
+                if (rangeMatch) {
+                    const [, startDay, endDay, timeStr] = rangeMatch;
+                    const dayOrder = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+                    const startIdx = dayOrder.indexOf(startDay);
+                    const endIdx = dayOrder.indexOf(endDay);
+
+                    if (startIdx !== -1 && endIdx !== -1) {
+                        for (let i = startIdx; i <= endIdx; i++) {
+                            const dayName = daysMap[dayOrder[i]];
+                            const scheduleIdx = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'].indexOf(dayName);
+                            if (scheduleIdx !== -1) {
+                                schedule[scheduleIdx].hours = timeStr.includes('off') ? 'Closed' : timeStr;
+                            }
+                        }
+                    }
+                    return;
+                }
+
+                // handle individual days like "Mo 09:00-17:00" or "We off"
+                for (const [abbrev, fullDay] of Object.entries(daysMap)) {
+                    if (trimmed.startsWith(abbrev + ' ')) {
+                        const timeOnly = trimmed.substring(abbrev.length + 1);
+                        const dayIndex = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'].indexOf(fullDay);
+                        if (dayIndex !== -1) {
+                            schedule[dayIndex].hours = timeOnly.includes('off') ? 'Closed' : timeOnly;
+                        }
+                        break;
+                    }
+                }
+            });
+
+            return schedule;
+        }
+
+        // handle simple time ranges like "09:00-17:00" (apply to all days)
+        const simpleTimePattern = /^\d{1,2}:\d{2}-\d{1,2}:\d{2}$/;
+        if (simpleTimePattern.test(hours)) {
+            return Array(7).fill(0).map((_, i) => ({
+                day: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][i],
+                hours: hours
+            }));
+        }
+
+        // handle formats like "Mo,Tu,We,Th,Fr 09:00-17:00"
+        const commaPattern = /^([A-Za-z,]+)\s+(\d{1,2}:\d{2}-\d{1,2}:\d{2})$/;
+        const commaMatch = hours.match(commaPattern);
+        if (commaMatch) {
+            const [, daysList, timeStr] = commaMatch;
+            const schedule = [
+                { day: "Monday", hours: "Closed" },
+                { day: "Tuesday", hours: "Closed" },
+                { day: "Wednesday", hours: "Closed" },
+                { day: "Thursday", hours: "Closed" },
+                { day: "Friday", hours: "Closed" },
+                { day: "Saturday", hours: "Closed" },
+                { day: "Sunday", hours: "Closed" },
+            ];
+
+            const days = daysList.split(',');
+            days.forEach(day => {
+                const trimmedDay = day.trim();
+                if (daysMap[trimmedDay]) {
+                    const fullDay = daysMap[trimmedDay];
+                    const dayIndex = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'].indexOf(fullDay);
+                    if (dayIndex !== -1) {
+                        schedule[dayIndex].hours = timeStr;
+                    }
+                }
+            });
+
+            return schedule;
+        }
+
+        // if we get here, we have some format but couldn't parse it
+        // return a generic schedule showing the raw hours for each day
+        return Array(7).fill(0).map((_, i) => ({
+            day: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][i],
+            hours: hours
+        }));
+
+    } catch (error) {
+        console.error('Error parsing opening hours:', error);
+        return null;
+    }
+}
+
+// extract closing time from operating hours
+export function extractClosingTime(hours?: string): string | null {
+    if (!hours || hours === "N/A" || hours === "Unknown" || hours.trim() === "") {
+        return null;
+    }
+
+    // handle 24/7
+    if (hours === "24/7") {
+        return "24 hours";
+    }
+
+    // get current day
+    const today = new Date();
+    const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const currentDay = dayNames[today.getDay()];
+
+    // parse the hours and find today's schedule
+    const parsed = parseOpeningHours(hours);
+    if (parsed) {
+        const todaySchedule = parsed.find(s => s.day === currentDay);
+        if (todaySchedule && todaySchedule.hours !== 'Closed') {
+            if (todaySchedule.hours === '24 hours') {
+                return '24 hours';
+            }
+            // Extract closing time from range like "9:00 AM - 5:00 PM"
+            if (todaySchedule.hours.includes('-')) {
+                const [, endTime] = todaySchedule.hours.split('-');
+                return convertTo12Hour(endTime.trim());
+            }
+        }
+    }
+
+    // fallback: try to extract from simple formats
+    if (hours.includes('-')) {
+        const parts = hours.split('-');
+        if (parts.length === 2) {
+            const endTime = parts[1].trim();
+            return convertTo12Hour(endTime);
+        }
+    }
+
+    return null;
+}
+
+// determine if clinic is currently open based on operating hours
+export function determineOpenStatus(hours?: string): { isOpen: boolean; hasData: boolean } {
+    if (!hours || hours === "N/A" || hours === "Unknown" || hours.trim() === "") {
+        return { isOpen: false, hasData: false };
+    }
+
+    // handle 24/7
+    if (hours === "24/7") {
+        return { isOpen: true, hasData: true };
+    }
+
+    const now = new Date();
+    const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const currentDay = dayNames[now.getDay()];
+    const currentTime = now.getHours() * 60 + now.getMinutes(); // Current time in minutes
+
+    // parse the hours
+    const parsed = parseOpeningHours(hours);
+    if (parsed) {
+        const todaySchedule = parsed.find(s => s.day === currentDay);
+        if (todaySchedule) {
+            if (todaySchedule.hours === 'Closed') {
+                return { isOpen: false, hasData: true };
+            }
+            if (todaySchedule.hours === '24 hours') {
+                return { isOpen: true, hasData: true };
+            }
+
+            // Parse time range
+            if (todaySchedule.hours.includes('-')) {
+                const timeRange = todaySchedule.hours.replace(/AM|PM/gi, '').trim();
+                const [startStr, endStr] = timeRange.split('-');
+
+                const startTime = parseTimeToMinutes(startStr.trim());
+                const endTime = parseTimeToMinutes(endStr.trim());
+
+                if (startTime !== -1 && endTime !== -1) {
+                    // Handle overnight hours (e.g., 22:00-06:00)
+                    if (endTime < startTime) {
+                        return {
+                            isOpen: currentTime >= startTime || currentTime <= endTime,
+                            hasData: true
+                        };
+                    } else {
+                        return {
+                            isOpen: currentTime >= startTime && currentTime <= endTime,
+                            hasData: true
+                        };
+                    }
+                }
+            }
+        }
+        return { isOpen: false, hasData: true };
+    }
+
+    // fallback for simple formats
+    if (hours.includes('-')) {
+        const [startStr, endStr] = hours.split('-');
+        const startTime = parseTimeToMinutes(startStr.trim());
+        const endTime = parseTimeToMinutes(endStr.trim());
+
+        if (startTime !== -1 && endTime !== -1) {
+            if (endTime < startTime) {
+                return {
+                    isOpen: currentTime >= startTime || currentTime <= endTime,
+                    hasData: true
+                };
+            } else {
+                return {
+                    isOpen: currentTime >= startTime && currentTime <= endTime,
+                    hasData: true
+                };
+            }
+        }
+    }
+
+    return { isOpen: false, hasData: false };
+}
+
+// convert time string to minutes since midnight
+function parseTimeToMinutes(timeStr: string): number {
+    if (!timeStr) return -1;
+
+    const parts = timeStr.split(':');
+    if (parts.length !== 2) return -1;
+
+    const hours = parseInt(parts[0]);
+    const minutes = parseInt(parts[1]);
+
+    if (isNaN(hours) || isNaN(minutes) || hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+        return -1;
+    }
+
+    return hours * 60 + minutes;
+}


### PR DESCRIPTION
- Fixed Hours Parsing Logic
-- previous parsing function was too restrictive and would fall back to "check with facility" or "hours not available" for many valid formats for facilities with available operating hours data.  
-- new updated parser should handle weekday ranges, all days same hours, semicolon-separated, day ranges within semicolons, simple time ranges, and comma-separated days
- Changed to 12-hour format (for better readability)
-- previously 24-hour format
- Fixed popup to show accurate Closing Time
-- previously showed **all** operating hours for facilities that had the proper data
- Fixed Open/Closed badge in More Info panel and Clinic card
-- previously showed "open" for all locations regardless of whether it was actually open or not
-- should now also **only** show the badge IF actual hours data is available per facility, ELSE, no status badge is shown 
--- this will avoid misleading information
 
Examples for **walk-in _with_ operating hours data**:
<img width="1070" height="534" alt="image" src="https://github.com/user-attachments/assets/cf5d9ac4-962a-413e-b1c2-992d25d8d532" />
Examples for **hospital _with_ operating hours data**:
<img width="1070" height="534" alt="image" src="https://github.com/user-attachments/assets/d47c24d3-31c7-436c-b982-8831259aac27" />
Examples for **walk-in _withou_ operating hours data**:
<img width="1064" height="532" alt="image" src="https://github.com/user-attachments/assets/a9c355ae-f4f0-42cf-a2aa-9b1707161e3b" />
Examples for **hospital _without_ operating hours data**:
<img width="1070" height="534" alt="image" src="https://github.com/user-attachments/assets/9d79819e-f777-4be9-ae31-069f6ff6ac74" />

Fix for PR #61 (#18) 


